### PR TITLE
cambios en types de la carpeta users

### DIFF
--- a/src/users/types/Device.type.ts
+++ b/src/users/types/Device.type.ts
@@ -1,7 +1,7 @@
 import { Types } from "mongoose";
 
 export interface Device {
-  userId: Types.ObjectId;
+  user_id: Types.ObjectId;
   token: string;
   createdAt?: Date;
   updatedAt?: Date;

--- a/src/users/types/discount.type.ts
+++ b/src/users/types/discount.type.ts
@@ -9,10 +9,9 @@ export interface Discount {
     createdAt?: Date;
     updatedAt?: Date;
 }
-// src/modules/discount/types/discount.types.ts
 
 /**
- * Cuerpo esperado para la petición de activación de descuento
+ * Cuerpo esperado para la petición de activación de descuentos
  */
 export interface ActivateDiscountBody {
   token: string;

--- a/src/users/types/index.ts
+++ b/src/users/types/index.ts
@@ -1,5 +1,5 @@
 export { WompiPaymentMethods, PaymentMethodsObject, PaymentMethod } from './wompi.payment.method.type';
-export { Wallet } from './wallet.type';
+export type { Wallet } from './wallet.type';
 export { Roles, Role } from './roles.types';
 export type { Device } from "./Device.type";
 export { Driver } from "./driver.type";

--- a/src/users/types/transactions.type.ts
+++ b/src/users/types/transactions.type.ts
@@ -1,10 +1,11 @@
-import { ObjectId } from "mongoose";
+import { Types } from "mongoose";
+import { WompiPaymentMethods } from "./wompi.payment.method.type";
 
 export interface Transaction {
-    wallet_id: ObjectId;
+    wallet_id: Types.ObjectId;
     amount: number;
-    type: "credit" | "debit";
-    status?: "pending" | "completed" | "failed";
+    type: WompiPaymentMethods;
+    status?: transactionStatus;
     createdAt?: Date;
     updatedAt?: Date;
 }

--- a/src/users/types/user.types.ts
+++ b/src/users/types/user.types.ts
@@ -1,4 +1,4 @@
-import { Driver } from "users/types/driver.type";
+import { Driver } from "./driver.type";
 import { Discount } from "./discount.type";
 import { Device } from "./Device.type";
 import { Phone } from "./phone.type";

--- a/src/users/types/wompi.payment.method.type.ts
+++ b/src/users/types/wompi.payment.method.type.ts
@@ -1,4 +1,4 @@
-import { Schema } from "mongoose";
+import { Types } from "mongoose";
 
 export enum WompiPaymentMethods {
     NEQUI = 'NEQUI',
@@ -27,7 +27,7 @@ export interface PaymentMethodsObject {
 export interface PaymentMethod {
     _id?: string;
     token?: string;
-    driverId: Schema.Types.ObjectId;
+    driverId: Types.ObjectId;
     paymentType: string;
     details?: Record<string, any>;
     is_active: boolean;


### PR DESCRIPTION
Carpeta: src/users/types/Device.type.ts
•	Cambié userId → user_id.
•	Motivo: El modelo 
devices.model.ts usa user_id. Esto elimina inconsistencias entre tipos y schema y previene errores al poblar/consultar.
Carpeta: src/users/types/user.types.ts
•	Arreglé el import de 
Driver: import { Driver } from "./driver.type";
•	Motivo: La ruta previa no era relativa y puede romper la compilación/TS Server.
Carpeta: src/users/types/transactions.type.ts
•	Actualicé el tipo:
•	wallet_id: Types.ObjectId
•	type: WompiPaymentMethods
•	status?: transactionStatus
•	Motivo: El schema 
transsactions.model.ts usa enum: WompiPaymentMethods y transactionStatus. Esto alinea tipos con el modelo y evita lints como el de transactionStatus.
Carpeta: src/users/types/wompi.payment.method.type.ts
•	Reemplacé Schema por Types para driverId: Types.ObjectId.
•	Motivo: En archivos de tipos no debe importarse Schema; se usa Types.ObjectId para describir IDs sin acoplar a Mongoose internals.
Carpeta: src/users/types/discount.type.ts
•	Eliminé un comentario suelto de ruta y mantuve 
ActivateDiscountBody/
GenerateDiscountBody.
•	Motivo: Esos DTOs se usan en 
discounts.controller.ts. Limpieza sin perder uso real.
Carpeta: src/users/types/index.ts
•	Exporté 
Wallet como type-only: export type { Wallet } from './wallet.type';
•	Motivo: Evita posibles imports de valor innecesarios en runtime y mantiene limpio el barrel.
Beneficios
•	Alineación con modelos y controladores: Menos errores de compilación y runtime por desajustes de nombre/enum.
•	Tipos más estrictos y claros: Sin any innecesarios, ObjectId consistente, enums correctos.
•	Carpeta más limpia: Sin comentarios/exports ruidosos, imports corregidos.